### PR TITLE
Horizontal repost carousel

### DIFF
--- a/src/screens/Settings/DeerSettings.tsx
+++ b/src/screens/Settings/DeerSettings.tsx
@@ -31,6 +31,10 @@ import {
   useNoDiscoverFallback,
   useSetNoDiscoverFallback,
 } from '#/state/preferences/no-discover-fallback'
+import {
+  useRepostCarouselEnabled,
+  useSetRepostCarouselEnabled,
+} from '#/state/preferences/repost-carousel-enabled'
 import {TextInput} from '#/view/com/modals/util'
 import * as SettingsList from '#/screens/Settings/components/SettingsList'
 import {atoms as a} from '#/alf'
@@ -134,6 +138,9 @@ export function DeerSettingsScreen({}: Props) {
 
   const location = useGeolocation()
   const setLocationControl = Dialog.useDialogControl()
+
+  const repostCarouselEnabled = useRepostCarouselEnabled()
+  const setRepostCarouselEnabled = useSetRepostCarouselEnabled()
 
   const [gates, setGatesView] = useState(Object.fromEntries(useGatesCache()))
   const dangerousSetGate = useDangerousSetGate()
@@ -283,6 +290,17 @@ export function DeerSettingsScreen({}: Props) {
             <SettingsList.ItemText>
               <Trans>Tweaks</Trans>
             </SettingsList.ItemText>
+            <Toggle.Item
+              name="repost_carousel"
+              label={_(msg`Combine reposts into a horizontal carousel`)}
+              value={repostCarouselEnabled}
+              onChange={value => setRepostCarouselEnabled(value)}
+              style={[a.w_full]}>
+              <Toggle.LabelText style={[a.flex_1]}>
+                <Trans>Combine reposts into a horizontal carousel</Trans>
+              </Toggle.LabelText>
+              <Toggle.Platform />
+            </Toggle.Item>
             <Toggle.Item
               name="no_discover_fallback"
               label={_(msg`Do not fall back to discover feed`)}

--- a/src/state/persisted/schema.ts
+++ b/src/state/persisted/schema.ts
@@ -130,6 +130,7 @@ const schema = z.object({
   directFetchRecords: z.boolean().optional(),
   noAppLabelers: z.boolean().optional(),
   noDiscoverFallback: z.boolean().optional(),
+  repostCarouselEnabled: z.boolean().optional(),
 
   /** @deprecated */
   mutedThreads: z.array(z.string()),
@@ -189,6 +190,7 @@ export const defaults: Schema = {
   directFetchRecords: false,
   noAppLabelers: false,
   noDiscoverFallback: false,
+  repostCarouselEnabled: false,
 }
 
 export function tryParse(rawData: string): Schema | undefined {

--- a/src/state/preferences/index.tsx
+++ b/src/state/preferences/index.tsx
@@ -14,6 +14,7 @@ import {Provider as LanguagesProvider} from './languages'
 import {Provider as LargeAltBadgeProvider} from './large-alt-badge'
 import {Provider as NoAppLabelersProvider} from './no-app-labelers'
 import {Provider as NoDiscoverProvider} from './no-discover-fallback'
+import {Provider as RepostCarouselProvider} from './repost-carousel-enabled'
 import {Provider as SubtitlesProvider} from './subtitles'
 import {Provider as TrendingSettingsProvider} from './trending'
 import {Provider as UsedStarterPacksProvider} from './used-starter-packs'
@@ -52,8 +53,10 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
                               <UsedStarterPacksProvider>
                                 <SubtitlesProvider>
                                   <TrendingSettingsProvider>
-                                    <KawaiiProvider>{children}</KawaiiProvider>
-                                  </TrendingSettingsProvider>
+                                    <RepostCarouselProvider>
+                                        <KawaiiProvider>{children}</KawaiiProvider>
+                                    </RepostCarouselProvider>
+                                </TrendingSettingsProvider>
                                 </SubtitlesProvider>
                               </UsedStarterPacksProvider>
                             </AutoplayProvider>

--- a/src/state/preferences/repost-carousel-enabled.tsx
+++ b/src/state/preferences/repost-carousel-enabled.tsx
@@ -1,0 +1,42 @@
+import React from 'react'
+
+import * as persisted from '#/state/persisted'
+
+type StateContext = boolean
+type SetContext = (v: boolean) => void
+
+const stateContext = React.createContext<StateContext>(
+  Boolean(persisted.defaults.repostCarouselEnabled),
+)
+const setContext = React.createContext<SetContext>((_: boolean) => {})
+
+export function Provider({children}: {children: React.ReactNode}) {
+  const [state, setState] = React.useState(
+    Boolean(persisted.get('repostCarouselEnabled')),
+  )
+
+  const setStateWrapped = React.useCallback(
+    (value: persisted.Schema['repostCarouselEnabled']) => {
+      setState(Boolean(value))
+      persisted.write('repostCarouselEnabled', value)
+    },
+    [setState],
+  )
+
+  React.useEffect(() => {
+    return persisted.onUpdate('repostCarouselEnabled', nextValue => {
+      setState(Boolean(nextValue))
+    })
+  }, [setStateWrapped])
+
+  return (
+    <stateContext.Provider value={state}>
+      <setContext.Provider value={setStateWrapped}>
+        {children}
+      </setContext.Provider>
+    </stateContext.Provider>
+  )
+}
+
+export const useRepostCarouselEnabled = () => React.useContext(stateContext)
+export const useSetRepostCarouselEnabled = () => React.useContext(setContext)

--- a/src/view/com/posts/PostFeedItem.tsx
+++ b/src/view/com/posts/PostFeedItem.tsx
@@ -1,23 +1,23 @@
 import React, {memo, useMemo, useState} from 'react'
 import {StyleSheet, View} from 'react-native'
 import {
-  AppBskyActorDefs,
+  type AppBskyActorDefs,
   AppBskyFeedDefs,
   AppBskyFeedPost,
   AppBskyFeedThreadgate,
   AtUri,
-  ModerationDecision,
+  type ModerationDecision,
   RichText as RichTextAPI,
 } from '@atproto/api'
 import {
   FontAwesomeIcon,
-  FontAwesomeIconStyle,
+  type FontAwesomeIconStyle,
 } from '@fortawesome/react-native-fontawesome'
 import {msg, Trans} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 import {useQueryClient} from '@tanstack/react-query'
 
-import {isReasonFeedSource, ReasonFeedSource} from '#/lib/api/feed/types'
+import {isReasonFeedSource, type ReasonFeedSource} from '#/lib/api/feed/types'
 import {MAX_POST_LINES} from '#/lib/constants'
 import {usePalette} from '#/lib/hooks/usePalette'
 import {makeProfileLink} from '#/lib/routes/links'
@@ -25,7 +25,7 @@ import {sanitizeDisplayName} from '#/lib/strings/display-names'
 import {sanitizeHandle} from '#/lib/strings/handles'
 import {countLines} from '#/lib/strings/helpers'
 import {s} from '#/lib/styles'
-import {POST_TOMBSTONE, Shadow, usePostShadow} from '#/state/cache/post-shadow'
+import {POST_TOMBSTONE, type Shadow, usePostShadow} from '#/state/cache/post-shadow'
 import {useFeedFeedbackContext} from '#/state/feed-feedback'
 import {precacheProfile} from '#/state/queries/profile'
 import {useSession} from '#/state/session'
@@ -43,7 +43,7 @@ import {Repost_Stroke2_Corner2_Rounded as RepostIcon} from '#/components/icons/R
 import {ContentHider} from '#/components/moderation/ContentHider'
 import {LabelsOnMyPost} from '#/components/moderation/LabelsOnMe'
 import {PostAlerts} from '#/components/moderation/PostAlerts'
-import {AppModerationCause} from '#/components/Pills'
+import {type AppModerationCause} from '#/components/Pills'
 import {ProfileHoverCard} from '#/components/ProfileHoverCard'
 import {RichText} from '#/components/RichText'
 import {SubtleWebHover} from '#/components/SubtleWebHover'
@@ -69,6 +69,7 @@ interface FeedItemProps {
   hideTopBorder?: boolean
   isParentBlocked?: boolean
   isParentNotFound?: boolean
+  isCarouselItem?: boolean
 }
 
 export function PostFeedItem({
@@ -86,6 +87,7 @@ export function PostFeedItem({
   isParentBlocked,
   isParentNotFound,
   rootPost,
+  isCarouselItem,
 }: FeedItemProps & {
   post: AppBskyFeedDefs.PostView
   rootPost: AppBskyFeedDefs.PostView
@@ -121,6 +123,7 @@ export function PostFeedItem({
         hideTopBorder={hideTopBorder}
         isParentBlocked={isParentBlocked}
         isParentNotFound={isParentNotFound}
+        isCarouselItem={isCarouselItem}
         rootPost={rootPost}
       />
     )
@@ -143,6 +146,7 @@ let FeedItemInner = ({
   hideTopBorder,
   isParentBlocked,
   isParentNotFound,
+  isCarouselItem,
   rootPost,
 }: FeedItemProps & {
   richText: RichTextAPI
@@ -258,7 +262,7 @@ let FeedItemInner = ({
       }}>
       <SubtleWebHover hover={hover} />
       <View style={{flexDirection: 'row', gap: 10, paddingLeft: 8}}>
-        <View style={{width: 42}}>
+        <View style={{width: isCarouselItem ? 0 : 42}}>
           {isThreadChild && (
             <View
               style={[

--- a/src/view/com/posts/PostFeedItemCarousel.tsx
+++ b/src/view/com/posts/PostFeedItemCarousel.tsx
@@ -1,0 +1,148 @@
+import React from 'react'
+import {Dimensions, ScrollView, View} from 'react-native'
+import {msg, Plural} from '@lingui/macro'
+import {useLingui} from '@lingui/react'
+
+import {type FeedPostSlice} from '#/state/queries/post-feed'
+import {BlockDrawerGesture} from '#/view/shell/BlockDrawerGesture'
+import {atoms as a, useTheme} from '#/alf'
+import {Button, ButtonIcon} from '#/components/Button'
+import {
+  ChevronLeft_Stroke2_Corner0_Rounded as ChevronLeft,
+  ChevronRight_Stroke2_Corner0_Rounded as ChevronRight,
+} from '#/components/icons/Chevron'
+import {Text} from '#/components/Typography'
+import {PostFeedItem} from './PostFeedItem'
+
+const CARD_WIDTH = 320
+const CARD_INTERVAL = CARD_WIDTH + a.gap_md.gap
+
+export function PostFeedItemCarousel({items}: {items: FeedPostSlice[]}) {
+  const t = useTheme()
+  const {_} = useLingui()
+  const ref = React.useRef<ScrollView>(null)
+  const [scrollX, setScrollX] = React.useState(0)
+
+  const scrollTo = React.useCallback(
+    (item: number) => {
+      setScrollX(item)
+
+      ref.current?.scrollTo({
+        x: item * CARD_INTERVAL,
+        y: 0,
+        animated: true,
+      })
+    },
+    [ref],
+  )
+
+  const scrollLeft = React.useCallback(() => {
+    const newPos = scrollX > 0 ? scrollX - 1 : items.length - 1
+    scrollTo(newPos)
+  }, [scrollTo, scrollX, items.length])
+
+  const scrollRight = React.useCallback(() => {
+    const newPos = scrollX < items.length - 1 ? scrollX + 1 : 0
+    scrollTo(newPos)
+  }, [scrollTo, scrollX, items.length])
+
+  return (
+    <View
+      style={[a.border_t, t.atoms.border_contrast_low, t.atoms.bg_contrast_25]}>
+      <View
+        style={[
+          a.py_lg,
+          a.px_md,
+          a.pb_xs,
+          a.flex_row,
+          a.align_center,
+          a.justify_between,
+        ]}>
+        <Text style={[a.text_sm, a.font_bold, t.atoms.text_contrast_medium]}>
+          {items.length}{' '}
+          <Plural value={items.length} one="repost" other="reposts" />
+        </Text>
+        <View style={[a.gap_md, a.flex_row, a.align_end]}>
+          <Button
+            label={_(msg`Scroll carousel left`)}
+            size="tiny"
+            variant="ghost"
+            color="secondary"
+            shape="round"
+            onPress={() => scrollLeft()}>
+            <ButtonIcon icon={ChevronLeft} />
+          </Button>
+          <Button
+            label={_(msg`Scroll carousel right`)}
+            size="tiny"
+            variant="ghost"
+            color="secondary"
+            shape="round"
+            onPress={() => scrollRight()}>
+            <ButtonIcon icon={ChevronRight} />
+          </Button>
+        </View>
+      </View>
+      <BlockDrawerGesture>
+        <View>
+          <ScrollView
+            horizontal
+            snapToInterval={CARD_INTERVAL}
+            decelerationRate="fast"
+            /* TODO: figure out how to not get this to break on the last item
+            onScroll={e => {
+              setScrollX(Math.floor(e.nativeEvent.contentOffset.x / CARD_INTERVAL))
+            }}
+*/
+            ref={ref}>
+            <View
+              style={[
+                a.px_md,
+                a.pt_sm,
+                a.pb_lg,
+                a.flex_row,
+                a.gap_md,
+                a.align_start,
+              ]}>
+              {items.map(slice => {
+                const item = slice.items[0]
+
+                return (
+                  <View
+                    style={[
+                      {
+                        maxHeight: Dimensions.get('window').height * 0.65,
+                        width: CARD_WIDTH,
+                      },
+                      a.rounded_md,
+                      a.border,
+                      t.atoms.bg,
+                      t.atoms.border_contrast_low,
+                      a.flex_shrink_0,
+                      a.overflow_hidden,
+                    ]}
+                    key={item._reactKey}>
+                    <PostFeedItem
+                      post={item.post}
+                      record={item.record}
+                      reason={slice.reason}
+                      feedContext={slice.feedContext}
+                      moderation={item.moderation}
+                      parentAuthor={item.parentAuthor}
+                      isParentBlocked={item.isParentBlocked}
+                      isParentNotFound={item.isParentNotFound}
+                      hideTopBorder={true}
+                      isCarouselItem={true}
+                      rootPost={slice.items[0].post}
+                      showReplyTo={false}
+                    />
+                  </View>
+                )
+              })}
+            </View>
+          </ScrollView>
+        </View>
+      </BlockDrawerGesture>
+    </View>
+  )
+}

--- a/src/view/com/util/PostMeta.tsx
+++ b/src/view/com/util/PostMeta.tsx
@@ -1,9 +1,10 @@
-import React, {memo, useCallback} from 'react'
-import {StyleProp, View, ViewStyle} from 'react-native'
-import {AppBskyActorDefs, ModerationDecision} from '@atproto/api'
+import {memo, useCallback} from 'react'
+import {type StyleProp, View, type ViewStyle} from 'react-native'
+import {type AppBskyActorDefs, type ModerationDecision} from '@atproto/api'
 import {msg} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 import {useQueryClient} from '@tanstack/react-query'
+import type React from 'react'
 
 import {makeProfileLink} from '#/lib/routes/links'
 import {forceLTR} from '#/lib/strings/bidi'
@@ -53,7 +54,7 @@ let PostMeta = (opts: PostMetaOpts): React.ReactNode => {
   return (
     <View
       style={[
-        a.flex_1,
+        isAndroid ? a.flex_1 : a.flex_shrink,
         a.flex_row,
         a.align_center,
         a.pb_2xs,

--- a/src/view/com/util/images/ImageLayoutGrid.tsx
+++ b/src/view/com/util/images/ImageLayoutGrid.tsx
@@ -1,11 +1,12 @@
 import React from 'react'
-import {StyleProp, StyleSheet, View, ViewStyle} from 'react-native'
-import {AppBskyEmbedImages} from '@atproto/api'
+import {type StyleProp, StyleSheet, View, type ViewStyle} from 'react-native'
+import {type AppBskyEmbedImages} from '@atproto/api'
 
-import {HandleRef, useHandleRef} from '#/lib/hooks/useHandleRef'
+import {type HandleRef, useHandleRef} from '#/lib/hooks/useHandleRef'
+import {isAndroid} from '#/platform/detection'
 import {PostEmbedViewContext} from '#/view/com/util/post-embeds/types'
 import {atoms as a, useBreakpoints} from '#/alf'
-import {Dimensions} from '../../lightbox/ImageViewing/@types'
+import {type Dimensions} from '../../lightbox/ImageViewing/@types'
 import {GalleryItem} from './Gallery'
 
 interface ImageLayoutGridProps {
@@ -62,11 +63,13 @@ function ImageLayoutGridInner(props: ImageLayoutGridInnerProps) {
   const containerRef4 = useHandleRef()
   const thumbDimsRef = React.useRef<(Dimensions | null)[]>([])
 
+  const outerFlex = isAndroid ? a.flex_1 : a.flex_shrink
+
   switch (count) {
     case 2: {
       const containerRefs = [containerRef1, containerRef2]
       return (
-        <View style={[a.flex_1, a.flex_row, gap]}>
+        <View style={[outerFlex, a.flex_row, gap]}>
           <View style={[a.flex_1, {aspectRatio: 1}]}>
             <GalleryItem
               {...props}
@@ -92,7 +95,7 @@ function ImageLayoutGridInner(props: ImageLayoutGridInnerProps) {
     case 3: {
       const containerRefs = [containerRef1, containerRef2, containerRef3]
       return (
-        <View style={[a.flex_1, a.flex_row, gap]}>
+        <View style={[outerFlex, a.flex_row, gap]}>
           <View style={[a.flex_1, {aspectRatio: 1}]}>
             <GalleryItem
               {...props}


### PR DESCRIPTION
This adds a horizontal repost carousel akin to https://github.com/cheeaun/phanpy, as shown on https://bsky.app/profile/ntauthority.me/post/3llsxz7yri223.

<img width="645" alt="image" src="https://github.com/user-attachments/assets/38e40363-6697-4195-a529-1e8ec78f77d9" />

A few notes:
1. The navigation buttons (for web) were hastily added just now, they ideally would take in the current scroll position but this breaks at the end of a list.
2. Ideally there'd be some conventions here when it comes to adding preferences (e.g. placing all new preferences on the inside of the provider to reduce diff size?) as this seems to become a mess relatively quickly.
3. This used to work on iOS at least, I'm not sure if I tested it on Android, but yeah-
4. ... on iOS however, reposts with multiple media items break, so I'll treat this as a draft until I solve that (I'd need to put in some effort again to get deer building on iOS locally, or might await someone else to contribute some build changes related to this).