### PR TITLE
Added filter for follow notifications

### DIFF
--- a/src/screens/Settings/DeerSettings.tsx
+++ b/src/screens/Settings/DeerSettings.tsx
@@ -24,6 +24,10 @@ import {
   useSetDirectFetchRecords,
 } from '#/state/preferences/direct-fetch-records'
 import {
+  useHideFollowNotifications,
+  useSetHideFollowNotifications,
+} from '#/state/preferences/hide-follow-notifications'
+import {
   useNoAppLabelers,
   useSetNoAppLabelers,
 } from '#/state/preferences/no-app-labelers'
@@ -43,6 +47,7 @@ import {Button, ButtonText} from '#/components/Button'
 import * as Dialog from '#/components/Dialog'
 import * as Toggle from '#/components/forms/Toggle'
 import {Atom_Stroke2_Corner0_Rounded as DeerIcon} from '#/components/icons/Atom'
+import {Bell_Stroke2_Corner0_Rounded as BellIcon} from '#/components/icons/Bell'
 import {Eye_Stroke2_Corner0_Rounded as VisibilityIcon} from '#/components/icons/Eye'
 import {Earth_Stroke2_Corner2_Rounded as GlobeIcon} from '#/components/icons/Globe'
 import {Lab_Stroke2_Corner0_Rounded as BeakerIcon} from '#/components/icons/Lab'
@@ -135,6 +140,9 @@ export function DeerSettingsScreen({}: Props) {
 
   const noDiscoverFallback = useNoDiscoverFallback()
   const setNoDiscoverFallback = useSetNoDiscoverFallback()
+
+  const hideFollowNotifications = useHideFollowNotifications()
+  const setHideFollowNotifications = useSetHideFollowNotifications()
 
   const location = useGeolocation()
   const setLocationControl = Dialog.useDialogControl()
@@ -309,6 +317,24 @@ export function DeerSettingsScreen({}: Props) {
               style={[a.w_full]}>
               <Toggle.LabelText style={[a.flex_1]}>
                 <Trans>Do not fall back to discover feed</Trans>
+              </Toggle.LabelText>
+              <Toggle.Platform />
+            </Toggle.Item>
+          </SettingsList.Group>
+
+          <SettingsList.Group contentContainerStyle={[a.gap_sm]}>
+            <SettingsList.ItemIcon icon={BellIcon} />
+            <SettingsList.ItemText>
+              <Trans>Notification Filters</Trans>
+            </SettingsList.ItemText>
+            <Toggle.Item
+              name="hide_follow_notifications"
+              label={_(msg`Hide follow notifications`)}
+              value={hideFollowNotifications ?? false}
+              onChange={value => setHideFollowNotifications(value)}
+              style={[a.w_full]}>
+              <Toggle.LabelText style={[a.flex_1]}>
+                <Trans>Hide follow notifications</Trans>
               </Toggle.LabelText>
               <Toggle.Platform />
             </Toggle.Item>

--- a/src/screens/Settings/NotificationSettings.tsx
+++ b/src/screens/Settings/NotificationSettings.tsx
@@ -2,11 +2,7 @@ import {Text} from 'react-native'
 import {msg, Trans} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 
-import {AllNavigatorParams, NativeStackScreenProps} from '#/lib/routes/types'
-import {
-  useHideFollowNotifications,
-  useSetHideFollowNotifications,
-} from '#/state/preferences/hide-follow-notifications'
+import {type AllNavigatorParams, type NativeStackScreenProps} from '#/lib/routes/types'
 import {useNotificationFeedQuery} from '#/state/queries/notifications/feed'
 import {useNotificationSettingsMutation} from '#/state/queries/notifications/settings'
 import {atoms as a} from '#/alf'
@@ -36,9 +32,6 @@ export function NotificationSettingsScreen({}: Props) {
     isPending: isMutationPending,
     variables,
   } = useNotificationSettingsMutation()
-
-  const hideFollowNotifications = useHideFollowNotifications()
-  const setHideFollowNotifications = useSetHideFollowNotifications()
 
   const priority = isMutationPending
     ? variables[0] === 'enabled'
@@ -70,17 +63,6 @@ export function NotificationSettingsScreen({}: Props) {
               <SettingsList.ItemText>
                 <Trans>Notification filters</Trans>
               </SettingsList.ItemText>
-              <Toggle.Item
-                name="hide_follow_notifications"
-                label={_(msg`Hide follow notifications`)}
-                value={hideFollowNotifications ?? false}
-                onChange={value => setHideFollowNotifications(value)}
-                style={[a.w_full]}>
-                <Toggle.LabelText style={[a.flex_1]}>
-                  <Trans>Hide follow notifications</Trans>
-                </Toggle.LabelText>
-                <Toggle.Platform />
-              </Toggle.Item>
               <Toggle.Group
                 label={_(msg`Priority notifications`)}
                 type="checkbox"

--- a/src/screens/Settings/NotificationSettings.tsx
+++ b/src/screens/Settings/NotificationSettings.tsx
@@ -72,7 +72,7 @@ export function NotificationSettingsScreen({}: Props) {
                 <Toggle.Item
                   name="enabled"
                   label={_(msg`Enable priority notifications`)}
-                  style={[a.flex_1, a.justify_between, a.pt_sm]}>
+                  style={[a.flex_1, a.justify_between]}>
                   <Toggle.LabelText>
                     <Trans>Enable priority notifications</Trans>
                   </Toggle.LabelText>

--- a/src/screens/Settings/NotificationSettings.tsx
+++ b/src/screens/Settings/NotificationSettings.tsx
@@ -3,6 +3,10 @@ import {msg, Trans} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 
 import {AllNavigatorParams, NativeStackScreenProps} from '#/lib/routes/types'
+import {
+  useHideFollowNotifications,
+  useSetHideFollowNotifications,
+} from '#/state/preferences/hide-follow-notifications'
 import {useNotificationFeedQuery} from '#/state/queries/notifications/feed'
 import {useNotificationSettingsMutation} from '#/state/queries/notifications/settings'
 import {atoms as a} from '#/alf'
@@ -32,6 +36,9 @@ export function NotificationSettingsScreen({}: Props) {
     isPending: isMutationPending,
     variables,
   } = useNotificationSettingsMutation()
+
+  const hideFollowNotifications = useHideFollowNotifications()
+  const setHideFollowNotifications = useSetHideFollowNotifications()
 
   const priority = isMutationPending
     ? variables[0] === 'enabled'
@@ -63,6 +70,17 @@ export function NotificationSettingsScreen({}: Props) {
               <SettingsList.ItemText>
                 <Trans>Notification filters</Trans>
               </SettingsList.ItemText>
+              <Toggle.Item
+                name="hide_follow_notifications"
+                label={_(msg`Hide follow notifications`)}
+                value={hideFollowNotifications ?? false}
+                onChange={value => setHideFollowNotifications(value)}
+                style={[a.w_full]}>
+                <Toggle.LabelText style={[a.flex_1]}>
+                  <Trans>Hide follow notifications</Trans>
+                </Toggle.LabelText>
+                <Toggle.Platform />
+              </Toggle.Item>
               <Toggle.Group
                 label={_(msg`Priority notifications`)}
                 type="checkbox"
@@ -72,7 +90,7 @@ export function NotificationSettingsScreen({}: Props) {
                 <Toggle.Item
                   name="enabled"
                   label={_(msg`Enable priority notifications`)}
-                  style={[a.flex_1, a.justify_between]}>
+                  style={[a.flex_1, a.justify_between, a.pt_sm]}>
                   <Toggle.LabelText>
                     <Trans>Enable priority notifications</Trans>
                   </Toggle.LabelText>

--- a/src/state/persisted/schema.ts
+++ b/src/state/persisted/schema.ts
@@ -131,6 +131,7 @@ const schema = z.object({
   noAppLabelers: z.boolean().optional(),
   noDiscoverFallback: z.boolean().optional(),
   repostCarouselEnabled: z.boolean().optional(),
+  hideFollowNotifications: z.boolean().optional(),
 
   /** @deprecated */
   mutedThreads: z.array(z.string()),

--- a/src/state/persisted/schema.ts
+++ b/src/state/persisted/schema.ts
@@ -192,6 +192,7 @@ export const defaults: Schema = {
   noAppLabelers: false,
   noDiscoverFallback: false,
   repostCarouselEnabled: false,
+  hideFollowNotifications: false,
 }
 
 export function tryParse(rawData: string): Schema | undefined {

--- a/src/state/preferences/hide-follow-notifications.tsx
+++ b/src/state/preferences/hide-follow-notifications.tsx
@@ -1,0 +1,52 @@
+import React from 'react'
+
+import * as persisted from '#/state/persisted'
+
+type StateContext = persisted.Schema['hideFollowNotifications']
+type SetContext = (v: persisted.Schema['hideFollowNotifications']) => void
+
+const stateContext = React.createContext<StateContext>(
+  persisted.defaults.hideFollowNotifications,
+)
+const setContext = React.createContext<SetContext>(
+  (_: persisted.Schema['hideFollowNotifications']) => {},
+)
+
+export function Provider({children}: React.PropsWithChildren<{}>) {
+  const [state, setState] = React.useState(
+    persisted.get('hideFollowNotifications'),
+  )
+
+  const setStateWrapped = React.useCallback(
+    (hideFollowNotifications: persisted.Schema['hideFollowNotifications']) => {
+      setState(hideFollowNotifications)
+      persisted.write('hideFollowNotifications', hideFollowNotifications)
+    },
+    [setState],
+  )
+
+  React.useEffect(() => {
+    return persisted.onUpdate(
+      'hideFollowNotifications',
+      nextHideFollowNotifications => {
+        setState(nextHideFollowNotifications)
+      },
+    )
+  }, [setStateWrapped])
+
+  return (
+    <stateContext.Provider value={state}>
+      <setContext.Provider value={setStateWrapped}>
+        {children}
+      </setContext.Provider>
+    </stateContext.Provider>
+  )
+}
+
+export function useHideFollowNotifications() {
+  return React.useContext(stateContext)
+}
+
+export function useSetHideFollowNotifications() {
+  return React.useContext(setContext)
+}

--- a/src/state/preferences/index.tsx
+++ b/src/state/preferences/index.tsx
@@ -8,6 +8,7 @@ import {Provider as DisableHapticsProvider} from './disable-haptics'
 import {Provider as ExternalEmbedsProvider} from './external-embeds-prefs'
 import {Provider as GoLinksProvider} from './go-links-enabled'
 import {Provider as HiddenPostsProvider} from './hidden-posts'
+import {Provider as FollowNotificationsProvider} from './hide-follow-notifications'
 import {Provider as InAppBrowserProvider} from './in-app-browser'
 import {Provider as KawaiiProvider} from './kawaii'
 import {Provider as LanguagesProvider} from './languages'
@@ -41,33 +42,35 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
       <AltTextRequiredProvider>
         <GoLinksProvider>
           <NoAppLabelersProvider>
-            <DirectFetchRecordsProvider>
-              <ConstellationProvider>
-                <NoDiscoverProvider>
-                  <LargeAltBadgeProvider>
-                    <ExternalEmbedsProvider>
-                      <HiddenPostsProvider>
-                        <InAppBrowserProvider>
-                          <DisableHapticsProvider>
-                            <AutoplayProvider>
-                              <UsedStarterPacksProvider>
-                                <SubtitlesProvider>
-                                  <TrendingSettingsProvider>
-                                    <RepostCarouselProvider>
+            <FollowNotificationsProvider>
+              <DirectFetchRecordsProvider>
+                <ConstellationProvider>
+                  <NoDiscoverProvider>
+                    <LargeAltBadgeProvider>
+                      <ExternalEmbedsProvider>
+                        <HiddenPostsProvider>
+                          <InAppBrowserProvider>
+                            <DisableHapticsProvider>
+                              <AutoplayProvider>
+                                <UsedStarterPacksProvider>
+                                  <SubtitlesProvider>
+                                    <TrendingSettingsProvider>
+                                      <RepostCarouselProvider>
                                         <KawaiiProvider>{children}</KawaiiProvider>
-                                    </RepostCarouselProvider>
-                                </TrendingSettingsProvider>
-                                </SubtitlesProvider>
-                              </UsedStarterPacksProvider>
-                            </AutoplayProvider>
-                          </DisableHapticsProvider>
-                        </InAppBrowserProvider>
-                      </HiddenPostsProvider>
-                    </ExternalEmbedsProvider>
-                  </LargeAltBadgeProvider>
-                </NoDiscoverProvider>
-              </ConstellationProvider>
-            </DirectFetchRecordsProvider>
+                                      </RepostCarouselProvider>
+                                    </TrendingSettingsProvider>
+                                  </SubtitlesProvider>
+                                </UsedStarterPacksProvider>
+                              </AutoplayProvider>
+                            </DisableHapticsProvider>
+                          </InAppBrowserProvider>
+                        </HiddenPostsProvider>
+                      </ExternalEmbedsProvider>
+                    </LargeAltBadgeProvider>
+                  </NoDiscoverProvider>
+                </ConstellationProvider>
+              </DirectFetchRecordsProvider>
+            </FollowNotificationsProvider>
           </NoAppLabelersProvider>
         </GoLinksProvider>
       </AltTextRequiredProvider>

--- a/src/state/queries/notifications/feed.ts
+++ b/src/state/queries/notifications/feed.ts
@@ -32,6 +32,7 @@ import {
   useQueryClient,
 } from '@tanstack/react-query'
 
+import {useHideFollowNotifications} from '#/state/preferences/hide-follow-notifications'
 import {useAgent} from '#/state/session'
 import {useThreadgateHiddenReplyUris} from '#/state/threadgate-hidden-replies'
 import {useModerationOpts} from '../../preferences/moderation-opts'
@@ -63,6 +64,7 @@ export function useNotificationFeedQuery(opts: {
   const agent = useAgent()
   const queryClient = useQueryClient()
   const moderationOpts = useModerationOpts()
+  const hideFollowNotifications = useHideFollowNotifications()
   const unreads = useUnreadNotificationsApi()
   const enabled = opts.enabled !== false
   const filter = opts.filter
@@ -111,6 +113,7 @@ export function useNotificationFeedQuery(opts: {
           cursor: pageParam,
           queryClient,
           moderationOpts,
+          hideFollowNotifications,
           fetchAdditionalData: true,
           reasons,
         })

--- a/src/state/queries/notifications/unread.tsx
+++ b/src/state/queries/notifications/unread.tsx
@@ -10,6 +10,7 @@ import EventEmitter from 'eventemitter3'
 import BroadcastChannel from '#/lib/broadcast'
 import {resetBadgeCount} from '#/lib/notifications/notifications'
 import {logger} from '#/logger'
+import {useHideFollowNotifications} from '#/state/preferences/hide-follow-notifications'
 import {useAgent, useSession} from '#/state/session'
 import {useModerationOpts} from '../../preferences/moderation-opts'
 import {truncateAndInvalidate} from '../util'
@@ -47,6 +48,7 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
   const agent = useAgent()
   const queryClient = useQueryClient()
   const moderationOpts = useModerationOpts()
+  const hideFollowNotifications = useHideFollowNotifications()
 
   const [numUnread, setNumUnread] = React.useState('')
 
@@ -153,6 +155,7 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
             limit: 40,
             queryClient,
             moderationOpts,
+            hideFollowNotifications,
             reasons: [],
 
             // only fetch subjects when the page is going to be used
@@ -201,7 +204,13 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
         }
       },
     }
-  }, [setNumUnread, queryClient, moderationOpts, agent])
+  }, [
+    setNumUnread,
+    queryClient,
+    moderationOpts,
+    hideFollowNotifications,
+    agent,
+  ])
   checkUnreadRef.current = api.checkUnread
 
   return (

--- a/src/state/queries/notifications/util.ts
+++ b/src/state/queries/notifications/util.ts
@@ -31,6 +31,7 @@ export async function fetchPage({
   limit,
   queryClient,
   moderationOpts,
+  hideFollowNotifications,
   fetchAdditionalData,
   reasons,
 }: {
@@ -39,6 +40,7 @@ export async function fetchPage({
   limit: number
   queryClient: QueryClient
   moderationOpts: ModerationOpts | undefined
+  hideFollowNotifications: boolean | undefined
   fetchAdditionalData: boolean
   reasons: string[]
 }): Promise<{
@@ -55,7 +57,7 @@ export async function fetchPage({
 
   // filter out notifs by mod rules
   const notifs = res.data.notifications.filter(
-    notif => !shouldFilterNotif(notif, moderationOpts),
+    notif => !shouldFilterNotif(notif, moderationOpts, hideFollowNotifications),
   )
 
   // group notifications which are essentially similar (follows, likes on a post)
@@ -106,9 +108,13 @@ export async function fetchPage({
 export function shouldFilterNotif(
   notif: AppBskyNotificationListNotifications.Notification,
   moderationOpts: ModerationOpts | undefined,
+  hideFollowNotifications: boolean | undefined,
 ): boolean {
   const containsImperative = !!notif.author.labels?.some(labelIsHideableOffense)
   if (containsImperative) {
+    return true
+  }
+  if (hideFollowNotifications && notif.reason == 'follow') {
     return true
   }
   if (!moderationOpts) {

--- a/src/view/screens/DebugMod.tsx
+++ b/src/view/screens/DebugMod.tsx
@@ -22,6 +22,7 @@ import {useLingui} from '@lingui/react'
 
 import {useGlobalLabelStrings} from '#/lib/moderation/useGlobalLabelStrings'
 import {CommonNavigatorParams, NativeStackScreenProps} from '#/lib/routes/types'
+import {useHideFollowNotifications} from '#/state/preferences/hide-follow-notifications'
 import {moderationOptsOverrideContext} from '#/state/preferences/moderation-opts'
 import {FeedNotification} from '#/state/queries/notifications/types'
 import {
@@ -866,7 +867,14 @@ function MockNotifItem({
   moderationOpts: ModerationOpts
 }) {
   const t = useTheme()
-  if (shouldFilterNotif(notif.notification, moderationOpts)) {
+  const hideFollowNotifications = useHideFollowNotifications()
+  if (
+    shouldFilterNotif(
+      notif.notification,
+      moderationOpts,
+      hideFollowNotifications,
+    )
+  ) {
     return (
       <P style={[t.atoms.bg_contrast_25, a.px_lg, a.py_md]}>
         Filtered from the feed


### PR DESCRIPTION
Hello! I promised to make a PR at some point, so here it is! Hopefully I haven't made any egregious errors...

Anyway, this PR adds a toggle in the notification settings which disables follow notifications. There are a few things that bug me with my implementation at the moment, however: Currently, we add a new `hideFollowNotifications` field to all notification-related fetching functions, but if we decide to add more notification filters, we'd need to add more individual fields. Instead maybe it'd be better if it was stored as a dictionary?

Also currently it requires you to refresh to see changes in the notification stream. Ideally, it would be invalidated for you.

Anyway, opinions? Is this an alright feature, or is it a bad fit for deer.social? Anything else I could fix or change?

