### PR TITLE
fix: video downloads not working for users on non-bsky PDSes

### DIFF
--- a/src/state/queries/resolve-identity.ts
+++ b/src/state/queries/resolve-identity.ts
@@ -1,0 +1,26 @@
+import {LRU} from './direct-fetch-record'
+
+const serviceCache = new LRU<`did:${string}`, string>()
+
+export async function resolvePdsServiceUrl(did: `did:${string}`) {
+  return await serviceCache.getOrTryInsertWith(did, async () => {
+    const docUrl = did.startsWith('did:plc:')
+      ? `https://plc.directory/${did}`
+      : `https://${did.substring(8)}/.well-known/did.json`
+
+    // TODO: validate!
+    const doc: {
+      service: {
+        serviceEndpoint: string
+        type: string
+      }[]
+    } = await (await fetch(docUrl)).json()
+    const service = doc.service.find(
+      s => s.type === 'AtprotoPersonalDataServer',
+    )?.serviceEndpoint
+
+    if (service === undefined)
+      throw new Error(`could not find a service for ${did}`)
+    return service
+  })
+}

--- a/src/view/com/util/forms/PostDropdownBtnMenuItems.tsx
+++ b/src/view/com/util/forms/PostDropdownBtnMenuItems.tsx
@@ -391,12 +391,36 @@ let PostDropdownMenuItems = ({
     })
   }, [isPinned, pinPostMutate, postCid, postUri])
 
+  // HUGE thanks to juli.ee and mary.my.id for pdsls and atcute/identity-resolver respectively
+  // as a reference for this code
+  const fetchPds = useCallback(async () => {
+    const did = post.author.did
+    let doc
+    if (did.startsWith('did:web:')) {
+      const hostPart = did.slice(8)
+      doc = await fetch(`https://${hostPart}/.well-known/did.json`)
+        .then(r => r.json())
+        .catch(() => null)
+    } else if (did.startsWith('did:plc')) {
+      doc = await fetch(`https://plc.directory/${encodeURIComponent(did)}`)
+        .then(r => r.json())
+        .catch(() => null)
+    }
+    if (!doc) return null
+    const pds = doc.service.find(
+      (service: {type: string}) => service.type === 'AtprotoPersonalDataServer',
+    )
+    if (!pds) return null
+    return pds.serviceEndpoint
+  }, [post])
+
   const onPressDownloadVideo = useCallback(async () => {
     if (post.embed?.$type !== 'app.bsky.embed.video#view') return
     const video = post.embed as AppBskyEmbedVideo.View
     const did = post.author.did
     const cid = video.cid
-    const uri = `https://bsky.social/xrpc/com.atproto.sync.getBlob?did=${did}&cid=${cid}`
+    const pdsUrl = await fetchPds()
+    const uri = `${pdsUrl}/xrpc/com.atproto.sync.getBlob?did=${did}&cid=${cid}`
 
     Toast.show('Downloading video...', 'download')
 
@@ -406,7 +430,7 @@ let PostDropdownMenuItems = ({
 
     if (success) Toast.show('Video downloaded', 'check')
     else Toast.show('Failed to download video', 'xmark')
-  }, [post])
+  }, [post, fetchPds])
 
   const onPressDownloadGif = useCallback(async () => {
     if (post.embed?.$type !== 'app.bsky.embed.external#view') return
@@ -427,7 +451,7 @@ let PostDropdownMenuItems = ({
     const embed = post.embed as AppBskyEmbedExternal.View
     // Janky workaround by checking if the domain is tenor.com
     const url = new URL(embed.external.uri)
-    return url.host == 'media.tenor.com'
+    return url.host === 'media.tenor.com'
   }, [post])
 
   const onBlockAuthor = useCallback(async () => {


### PR DESCRIPTION
Fixes https://github.com/a-viv-a/deer-social/issues/30#issuecomment-2840074615

So sorry, I completely missed this fact in my previous PR, hopefully this can rectify it.

Previous implementation used `bsky.social` as endpoint for getting blobs, but this does not work for users on other PDSes. New implementation fetches did doc for author's did, and determines PDS url from the document itself.

Tested on pds/non-pds authors. The code for fetching the pds has been tested with did:web, but I couldn't find any videos posted by any did:web users to confirm it works integrated, no reason to assume it won't. Android has also been tested.

