### PR TITLE
feat: link to website for handles

### DIFF
--- a/src/screens/Profile/Header/Handle.tsx
+++ b/src/screens/Profile/Header/Handle.tsx
@@ -23,7 +23,7 @@ export function ProfileHeaderHandle({
   const {_} = useLingui()
   const invalidHandle = isInvalidHandle(profile.handle)
   const blockHide = profile.viewer?.blocking || profile.viewer?.blockedBy
-  const isBskySocialHandle = profile.handle.endsWith('bsky.social')
+  const isBskySocialHandle = profile.handle.endsWith('.bsky.social')
   const showProfileInHandle = useShowLinkInHandle()
   return (
     <View

--- a/src/screens/Profile/Header/Handle.tsx
+++ b/src/screens/Profile/Header/Handle.tsx
@@ -1,12 +1,14 @@
 import {View} from 'react-native'
-import {AppBskyActorDefs} from '@atproto/api'
+import {type AppBskyActorDefs} from '@atproto/api'
 import {msg, Trans} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 
 import {isInvalidHandle} from '#/lib/strings/handles'
 import {isIOS} from '#/platform/detection'
-import {Shadow} from '#/state/cache/types'
+import {type Shadow} from '#/state/cache/types'
+import {useShowLinkInHandle} from '#/state/preferences/show-link-in-handle.tsx'
 import {atoms as a, useTheme, web} from '#/alf'
+import {InlineLinkText} from '#/components/Link.tsx'
 import {NewskieDialog} from '#/components/NewskieDialog'
 import {Text} from '#/components/Typography'
 
@@ -21,6 +23,8 @@ export function ProfileHeaderHandle({
   const {_} = useLingui()
   const invalidHandle = isInvalidHandle(profile.handle)
   const blockHide = profile.viewer?.blocking || profile.viewer?.blockedBy
+  const isBskySocialHandle = profile.handle.endsWith('bsky.social')
+  const showProfileInHandle = useShowLinkInHandle()
   return (
     <View
       style={[a.flex_row, a.gap_xs, a.align_center, {maxWidth: '100%'}]}
@@ -49,7 +53,19 @@ export function ProfileHeaderHandle({
             : [a.text_md, a.leading_snug, t.atoms.text_contrast_medium],
           web({wordBreak: 'break-all'}),
         ]}>
-        {invalidHandle ? _(msg`⚠Invalid Handle`) : `@${profile.handle}`}
+        {invalidHandle ? (
+          _(msg`⚠Invalid Handle`)
+        ) : showProfileInHandle && !isBskySocialHandle ? (
+          <InlineLinkText
+            to={`https://${profile.handle}`}
+            label={profile.handle}>
+            <Text style={[a.text_md, {color: t.palette.primary_500}]}>
+              @{profile.handle}
+            </Text>
+          </InlineLinkText>
+        ) : (
+          `@${profile.handle}`
+        )}
       </Text>
     </View>
   )

--- a/src/screens/Settings/DeerSettings.tsx
+++ b/src/screens/Settings/DeerSettings.tsx
@@ -51,6 +51,10 @@ import {
   useRepostCarouselEnabled,
   useSetRepostCarouselEnabled,
 } from '#/state/preferences/repost-carousel-enabled'
+import {
+  useSetShowLinkInHandle,
+  useShowLinkInHandle,
+} from '#/state/preferences/show-link-in-handle.tsx'
 import {useProfilesQuery} from '#/state/queries/profile'
 import * as SettingsList from '#/screens/Settings/components/SettingsList'
 import {atoms as a, useBreakpoints} from '#/alf'
@@ -270,6 +274,9 @@ export function DeerSettingsScreen({}: Props) {
 
   const repostCarouselEnabled = useRepostCarouselEnabled()
   const setRepostCarouselEnabled = useSetRepostCarouselEnabled()
+
+  const showLinkInHandle = useShowLinkInHandle()
+  const setShowLinkInHandle = useSetShowLinkInHandle()
 
   const [gates, setGatesView] = useState(Object.fromEntries(useGatesCache()))
   const dangerousSetGate = useDangerousSetGate()
@@ -496,6 +503,21 @@ export function DeerSettingsScreen({}: Props) {
               style={[a.w_full]}>
               <Toggle.LabelText style={[a.flex_1]}>
                 <Trans>Do not fall back to discover feed</Trans>
+              </Toggle.LabelText>
+              <Toggle.Platform />
+            </Toggle.Item>
+            <Toggle.Item
+              name="show_link_in_handle"
+              label={_(
+                msg`On non-bsky.social handles, show a link to that URL`,
+              )}
+              value={showLinkInHandle}
+              onChange={value => setShowLinkInHandle(value)}
+              style={[a.w_full]}>
+              <Toggle.LabelText style={[a.flex_1]}>
+                <Trans>
+                  On non-bsky.social handles, show a link to that URL
+                </Trans>
               </Toggle.LabelText>
               <Toggle.Platform />
             </Toggle.Item>

--- a/src/state/persisted/schema.ts
+++ b/src/state/persisted/schema.ts
@@ -133,6 +133,7 @@ const schema = z.object({
   repostCarouselEnabled: z.boolean().optional(),
   hideFollowNotifications: z.boolean().optional(),
   constellationInstance: z.string().optional(),
+  showLinkInHandle: z.boolean().optional(),
   deerVerification: z
     .object({
       enabled: z.boolean(),
@@ -201,6 +202,7 @@ export const defaults: Schema = {
   repostCarouselEnabled: false,
   hideFollowNotifications: false,
   constellationInstance: 'https://constellation.microcosm.blue/',
+  showLinkInHandle: false,
   deerVerification: {
     enabled: false,
     // https://deer.social/profile/did:plc:p2cp5gopk7mgjegy6wadk3ep/post/3lndyqyyr4k2k

--- a/src/state/preferences/index.tsx
+++ b/src/state/preferences/index.tsx
@@ -18,6 +18,7 @@ import {Provider as LargeAltBadgeProvider} from './large-alt-badge'
 import {Provider as NoAppLabelersProvider} from './no-app-labelers'
 import {Provider as NoDiscoverProvider} from './no-discover-fallback'
 import {Provider as RepostCarouselProvider} from './repost-carousel-enabled'
+import {Provider as ShowLinkInHandleProvider} from './show-link-in-handle'
 import {Provider as SubtitlesProvider} from './subtitles'
 import {Provider as TrendingSettingsProvider} from './trending'
 import {Provider as UsedStarterPacksProvider} from './used-starter-packs'
@@ -50,29 +51,31 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
                   <ConstellationInstanceProvider>
                     <DeerVerificationProvider>
                       <NoDiscoverProvider>
-                        <LargeAltBadgeProvider>
-                          <ExternalEmbedsProvider>
-                            <HiddenPostsProvider>
-                              <InAppBrowserProvider>
-                                <DisableHapticsProvider>
-                                  <AutoplayProvider>
-                                    <UsedStarterPacksProvider>
-                                      <SubtitlesProvider>
-                                        <TrendingSettingsProvider>
-                                          <RepostCarouselProvider>
-                                            <KawaiiProvider>
-                                              {children}
-                                            </KawaiiProvider>
-                                          </RepostCarouselProvider>
-                                        </TrendingSettingsProvider>
-                                      </SubtitlesProvider>
-                                    </UsedStarterPacksProvider>
-                                  </AutoplayProvider>
-                                </DisableHapticsProvider>
-                              </InAppBrowserProvider>
-                            </HiddenPostsProvider>
-                          </ExternalEmbedsProvider>
-                        </LargeAltBadgeProvider>
+                        <ShowLinkInHandleProvider>
+                          <LargeAltBadgeProvider>
+                            <ExternalEmbedsProvider>
+                              <HiddenPostsProvider>
+                                <InAppBrowserProvider>
+                                  <DisableHapticsProvider>
+                                    <AutoplayProvider>
+                                      <UsedStarterPacksProvider>
+                                        <SubtitlesProvider>
+                                          <TrendingSettingsProvider>
+                                            <RepostCarouselProvider>
+                                              <KawaiiProvider>
+                                                {children}
+                                              </KawaiiProvider>
+                                            </RepostCarouselProvider>
+                                          </TrendingSettingsProvider>
+                                        </SubtitlesProvider>
+                                      </UsedStarterPacksProvider>
+                                    </AutoplayProvider>
+                                  </DisableHapticsProvider>
+                                </InAppBrowserProvider>
+                              </HiddenPostsProvider>
+                            </ExternalEmbedsProvider>
+                          </LargeAltBadgeProvider>
+                        </ShowLinkInHandleProvider>
                       </NoDiscoverProvider>
                     </DeerVerificationProvider>
                   </ConstellationInstanceProvider>

--- a/src/state/preferences/show-link-in-handle.tsx
+++ b/src/state/preferences/show-link-in-handle.tsx
@@ -1,0 +1,47 @@
+import React from 'react'
+
+import * as persisted from '#/state/persisted'
+
+type StateContext = persisted.Schema['showLinkInHandle']
+type SetContext = (v: persisted.Schema['showLinkInHandle']) => void
+
+const stateContext = React.createContext<StateContext>(
+  persisted.defaults.showLinkInHandle,
+)
+const setContext = React.createContext<SetContext>(
+  (_: persisted.Schema['showLinkInHandle']) => {},
+)
+
+export function Provider({children}: React.PropsWithChildren<{}>) {
+  const [state, setState] = React.useState(persisted.get('showLinkInHandle'))
+
+  const setStateWrapped = React.useCallback(
+    (showLinkInHandle: persisted.Schema['showLinkInHandle']) => {
+      setState(showLinkInHandle)
+      persisted.write('showLinkInHandle', showLinkInHandle)
+    },
+    [setState],
+  )
+
+  React.useEffect(() => {
+    return persisted.onUpdate('showLinkInHandle', nextShowLinkInHandle => {
+      setState(nextShowLinkInHandle)
+    })
+  }, [setStateWrapped])
+
+  return (
+    <stateContext.Provider value={state}>
+      <setContext.Provider value={setStateWrapped}>
+        {children}
+      </setContext.Provider>
+    </stateContext.Provider>
+  )
+}
+
+export function useShowLinkInHandle() {
+  return React.useContext(stateContext)
+}
+
+export function useSetShowLinkInHandle() {
+  return React.useContext(setContext)
+}


### PR DESCRIPTION
closes #18 

adds a very simple ternary to return a link if the currently viewed profile's handle is not a default `*.bsky.social` handle.

styling for the link follows (afaik) proper styling for links in the rest of the app.

added a toggle under settings > deer > tweaks, the appropriate hooks for the toggle, and wraps it all in a provider as expected.

if the label on the tweak toggle should be reworded, lmk. i just picked sth that i thought worked well enough.
