### PR TITLE
 Add Android build workflow

### DIFF
--- a/.github/workflows/deer-build.yml
+++ b/.github/workflows/deer-build.yml
@@ -1,0 +1,43 @@
+name: Build deer.social
+on: workflow_dispatch
+
+jobs:
+  deer-build-android:
+    name: Build deer.social for Android
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: yarn
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          java-version: 17
+          distribution: temurin
+          cache: gradle
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v3
+      - name: Setup just
+        uses: extractions/setup-just@v2
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Copy example build settings
+        run: |
+          cp .env.example .env
+          cp google-services.json.example google-services.json
+
+      - name: Build
+        run: just dist-build-android-gradle
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: android
+          path: android/app/build/outputs/apk/release/app-release.apk

--- a/justfile
+++ b/justfile
@@ -8,6 +8,9 @@ dist-build-web: intl build-web
 [group('dist')]
 dist-build-android-sideload: intl build-android-sideload
 
+[group('dist')]
+dist-build-android-gradle: intl build-android-gradle
+
 [group('build')]
 intl:
     yarn intl:build
@@ -23,6 +26,11 @@ build-web: && postbuild-web
 [group('build')]
 build-android-sideload: prebuild-android
     eas build --local --platform android --profile sideload-android
+
+[group('build')]
+[working-directory: 'android']
+build-android-gradle: prebuild-android
+    ./gradlew app:assembleRelease
 
 [group('build')]
 postbuild-web:


### PR DESCRIPTION
Check this out:

![image](https://github.com/user-attachments/assets/5ab57d18-dd8e-40d5-acf2-404e0e9cf877)

This PR sets up a build workflow for the APK. It uses the Expo CLI and Gradle directly, so it doesn't require an account to build (unlike EAS in the Justfile). A built artifact is [on my fork](https://github.com/NotNite/deer-social/actions/runs/14851075128) for testing.

## Notes/unresolved questions

-  ~~I had to extract the localization strings (`yarn intl:extract`) for the Deer settings menu to show properly. Sorry about that being in one commit, I squashed and forgot I did that (lol).~~
   - edit: Now done in CI.
- ~~`on: push` seems *way* too often, that was just for testing. That should probably be removed or replaced with a tag pattern.~~
  - edit: Removed in commit 23d7c7d9403e1dce45f1bd456e50cab942f5d173. My justification is that the builds take a very long time, and they're production builds, so having them on every commit seems wrong. The workflow can be ran manually, or there could be another trigger setup for it (e.g. a tag pattern).
- Copying the default `.env`/`google-services.json` seems like a bad idea, but I can't entirely place *why* that would be a bad idea. I think it's fine, but if we ever need to fill out actual secrets there, it should probably be put into the GHA secrets system and then written out to the file in the workflow.
- ~~Builds take a long time (\~20m), and I don't think the builds are cached at all. There's probably a way to setup a cache and speed this up by a lot. The Yarn part is already cached, though.~~
  - edit: Enabled the Gradle cache in commit 99fbe5d422b44f15379fe56a1861a46c1b9c5bac. The cache is about 2GB (!), and it brought my build times from ~23m to ~18m.
- ~~This isn't using `sideload-android` (present in the Justfile) since I didn't think I needed it, but it might be wanted to add this here too.~~
  - edit: Seems EAS-specific, I don't think it's needed.
- ~~Since this is skipping EAS, should that gradlew command be moved into the Justfile?~~
  - edit: Done.
- ~~iOS wen~~ (I have no idea how to do this and I am allergic to Xcode so I call not it)

## Future distribution

(edit: Check the comments on this PR, I also evaluated Obtainium and it might be a better option than F-Droid. Leaving the below paragraphs untouched.)

I imagine the easiest way to distribute this APK will be through [F-Droid](https://f-droid.org/), which is kind of "the standard" for distributing open source apps (with a lot of options for manager apps like [Droid-ify](https://github.com/Droid-ify/client) or [Neo Store](https://github.com/NeoApplications/Neo-Store)). It would be a hell of a lot easier than dealing with Play Store, at least!

The TL;DR for setting up F-Droid is to install [fdroidserver](https://f-droid.org/docs/Installing_the_Server_and_Repo_Tools/) somewhere and [create a repository](https://f-droid.org/docs/Build_Server_Setup/). The artifact from the workflow can be copied to that server (automatically via webhook or something) and then deployed, and then it'll show up as an update for people who have the associated F-Droid repository added.

I can't really help set up F-Droid (needs to generate keys + be hosted somewhere), but I have done it before, so maybe I can dig up my old notes and put it somewhere to make this easier to accomplish. I'm pretty sure it would need to be on a dedicated VPS, I don't think it's feasible to run an F-Droid server off of GitHub Pages or something (correct me if I'm wrong!).

Another person on Bluesky suggested [Obtainium](https://obtainium.imranr.dev/), which seems to use GitHub releases, and might be easier. Both options are worth looking into IMO.