### PR TITLE
Add bsky.app for android intentFilters

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -164,6 +164,10 @@ module.exports = function (_config) {
                 scheme: 'https',
                 host: 'deer.social',
               },
+              {
+                scheme: 'https',
+                host: 'bsky.app',
+              },
               IS_DEV && {
                 scheme: 'http',
                 host: 'localhost:19006',


### PR DESCRIPTION
Closes https://github.com/a-viv-a/deer-social/issues/32 (properly, lol).

It turns out that the Expo docs actually lie! They say "Specifying `autoVerify` is required for Android App Links to work correctly.", but that's just... wrong? A friend pointed out how LibreTube can use YouTube's domains, so I decided to investigate. Turns out that with autoVerify disabled, `bsky.app` can still be added, just that the user has to manually enable the domain:

![image](https://github.com/user-attachments/assets/382b0426-e2ff-4ea3-a2f1-3dbb823bfb23)

If the official Bluesky app is installed alongside deer.social, bsky.app will be greyed out (first image) until it's disabled for the official app (second image):

![image](https://github.com/user-attachments/assets/4cd4dac8-809c-4b6c-bdf7-5a7d9a3756dd)
![image](https://github.com/user-attachments/assets/4f2e993e-28e6-4a92-b988-5716fb1dae6c)
