### PR TITLE
Add option to remove "Feeds ✨" tab/promo when one feed is selected

### DIFF
--- a/src/screens/Settings/DeerSettings.tsx
+++ b/src/screens/Settings/DeerSettings.tsx
@@ -35,6 +35,10 @@ import {
   useSetDirectFetchRecords,
 } from '#/state/preferences/direct-fetch-records'
 import {
+  useHideFeedsPromoTab,
+  useSetHideFeedsPromoTab,
+} from '#/state/preferences/hide-feeds-promo-tab'
+import {
   useHideFollowNotifications,
   useSetHideFollowNotifications,
 } from '#/state/preferences/hide-follow-notifications'
@@ -262,6 +266,9 @@ export function DeerSettingsScreen({}: Props) {
 
   const hideFollowNotifications = useHideFollowNotifications()
   const setHideFollowNotifications = useSetHideFollowNotifications()
+
+  const hideFeedsPromoTab = useHideFeedsPromoTab()
+  const setHideFeedsPromoTab = useSetHideFeedsPromoTab()
 
   const location = useGeolocation()
   const setLocationControl = Dialog.useDialogControl()
@@ -518,6 +525,19 @@ export function DeerSettingsScreen({}: Props) {
                 <Trans>
                   On non-bsky.social handles, show a link to that URL
                 </Trans>
+              </Toggle.LabelText>
+              <Toggle.Platform />
+            </Toggle.Item>
+            <Toggle.Item
+              name="hide_feeds_promo_tab"
+              label={_(
+                msg`Hide "Feeds ✨" tab when only one feed is selected`,
+              )}
+              value={hideFeedsPromoTab}
+              onChange={value => setHideFeedsPromoTab(value)}
+              style={[a.w_full]}>
+              <Toggle.LabelText style={[a.flex_1]}>
+                <Trans>Hide "Feeds ✨" tab when only one feed is selected</Trans>
               </Toggle.LabelText>
               <Toggle.Platform />
             </Toggle.Item>

--- a/src/state/persisted/schema.ts
+++ b/src/state/persisted/schema.ts
@@ -134,6 +134,7 @@ const schema = z.object({
   hideFollowNotifications: z.boolean().optional(),
   constellationInstance: z.string().optional(),
   showLinkInHandle: z.boolean().optional(),
+  hideFeedsPromoTab: z.boolean().optional(),
   deerVerification: z
     .object({
       enabled: z.boolean(),
@@ -203,6 +204,7 @@ export const defaults: Schema = {
   hideFollowNotifications: false,
   constellationInstance: 'https://constellation.microcosm.blue/',
   showLinkInHandle: false,
+  hideFeedsPromoTab: false,
   deerVerification: {
     enabled: false,
     // https://deer.social/profile/did:plc:p2cp5gopk7mgjegy6wadk3ep/post/3lndyqyyr4k2k

--- a/src/state/preferences/hide-feeds-promo-tab.tsx
+++ b/src/state/preferences/hide-feeds-promo-tab.tsx
@@ -1,0 +1,50 @@
+import React from 'react'
+
+import * as persisted from '#/state/persisted'
+
+// Preference: hideFeedsPromoTab – when true, suppress the "Feeds ✨" promotional tab in HomeHeader.
+
+type StateContext = persisted.Schema['hideFeedsPromoTab']
+// Same setter signature used across other preference modules
+type SetContext = (v: persisted.Schema['hideFeedsPromoTab']) => void
+
+const stateContext = React.createContext<StateContext>(
+  persisted.defaults.hideFeedsPromoTab,
+)
+const setContext = React.createContext<SetContext>(
+  (_: persisted.Schema['hideFeedsPromoTab']) => {},
+)
+
+export function Provider({children}: React.PropsWithChildren<{}>) {
+  const [state, setState] = React.useState(persisted.get('hideFeedsPromoTab'))
+
+  const setStateWrapped = React.useCallback(
+    (value: persisted.Schema['hideFeedsPromoTab']) => {
+      setState(value)
+      persisted.write('hideFeedsPromoTab', value)
+    },
+    [setState],
+  )
+
+  React.useEffect(() => {
+    return persisted.onUpdate('hideFeedsPromoTab', next => {
+      setState(next)
+    })
+  }, [setStateWrapped])
+
+  return (
+    <stateContext.Provider value={state}>
+      <setContext.Provider value={setStateWrapped}>
+        {children}
+      </setContext.Provider>
+    </stateContext.Provider>
+  )
+}
+
+export function useHideFeedsPromoTab() {
+  return React.useContext(stateContext)
+}
+
+export function useSetHideFeedsPromoTab() {
+  return React.useContext(setContext)
+} 

--- a/src/state/preferences/index.tsx
+++ b/src/state/preferences/index.tsx
@@ -8,9 +8,10 @@ import {Provider as DeerVerificationProvider} from './deer-verification'
 import {Provider as DirectFetchRecordsProvider} from './direct-fetch-records'
 import {Provider as DisableHapticsProvider} from './disable-haptics'
 import {Provider as ExternalEmbedsProvider} from './external-embeds-prefs'
+import {Provider as FollowNotificationsProvider} from './hide-follow-notifications'
 import {Provider as GoLinksProvider} from './go-links-enabled'
 import {Provider as HiddenPostsProvider} from './hidden-posts'
-import {Provider as FollowNotificationsProvider} from './hide-follow-notifications'
+import {Provider as HideFeedsPromoTabProvider} from './hide-feeds-promo-tab'
 import {Provider as InAppBrowserProvider} from './in-app-browser'
 import {Provider as KawaiiProvider} from './kawaii'
 import {Provider as LanguagesProvider} from './languages'
@@ -35,6 +36,7 @@ export {
 } from './external-embeds-prefs'
 export {useGoLinksEnabled, useSetGoLinksEnabled} from './go-links-enabled'
 export * from './hidden-posts'
+export {useHideFeedsPromoTab, useSetHideFeedsPromoTab} from './hide-feeds-promo-tab'
 export {useLabelDefinitions} from './label-defs'
 export {useLanguagePrefs, useLanguagePrefsApi} from './languages'
 export {useSetSubtitlesEnabled, useSubtitlesEnabled} from './subtitles'
@@ -63,7 +65,9 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
                                           <TrendingSettingsProvider>
                                             <RepostCarouselProvider>
                                               <KawaiiProvider>
-                                                {children}
+                                                <HideFeedsPromoTabProvider>
+                                                  {children}
+                                                </HideFeedsPromoTabProvider>
                                               </KawaiiProvider>
                                             </RepostCarouselProvider>
                                           </TrendingSettingsProvider>

--- a/src/view/com/home/HomeHeader.tsx
+++ b/src/view/com/home/HomeHeader.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import {useNavigation} from '@react-navigation/native'
+import {useHideFeedsPromoTab} from '#/state/preferences/hide-feeds-promo-tab'
 
 import {NavigationProp} from '#/lib/routes/types'
 import {FeedSourceInfo} from '#/state/queries/feed'
@@ -17,6 +18,7 @@ export function HomeHeader(
 ) {
   const {feeds} = props
   const {hasSession} = useSession()
+  const hideFeedsPromoTab = useHideFeedsPromoTab()
   const navigation = useNavigation<NavigationProp>()
 
   const hasPinnedCustom = React.useMemo<boolean>(() => {
@@ -29,11 +31,11 @@ export function HomeHeader(
 
   const items = React.useMemo(() => {
     const pinnedNames = feeds.map(f => f.displayName)
-    if (!hasPinnedCustom) {
+    if (!hasPinnedCustom && !hideFeedsPromoTab) {
       return pinnedNames.concat('Feeds ✨')
     }
     return pinnedNames
-  }, [hasPinnedCustom, feeds])
+  }, [hasPinnedCustom, hideFeedsPromoTab, feeds])
 
   const onPressFeedsLink = React.useCallback(() => {
     navigation.navigate('Feeds')
@@ -41,13 +43,13 @@ export function HomeHeader(
 
   const onSelect = React.useCallback(
     (index: number) => {
-      if (!hasPinnedCustom && index === items.length - 1) {
+      if (!hasPinnedCustom && !hideFeedsPromoTab && index === items.length - 1) {
         onPressFeedsLink()
       } else if (props.onSelect) {
         props.onSelect(index)
       }
     },
-    [items.length, onPressFeedsLink, props, hasPinnedCustom],
+    [items.length, onPressFeedsLink, props, hasPinnedCustom, hideFeedsPromoTab],
   )
 
   return (


### PR DESCRIPTION
I'll admit that this is a pretty low-stakes change. I just fixed the first issue that I saw (#62) to get acquainted with the codebase. This adds an option under "Tweaks" that lets you remove the "Feeds ✨" button when you only have one feed selected.

<img width="583" alt="image" src="https://github.com/user-attachments/assets/c6fc9a26-4bc7-46dd-8b90-d27b46b0e291" />

Now it looks like this:

<img width="583" alt="image" src="https://github.com/user-attachments/assets/e4c1ea53-05c5-453c-ac91-7d18c83e03f7" />

This change is extremely minor but should not require much maintenance, since it only really touches the settings page and two lines of code in the feed selector component.
